### PR TITLE
Fixed showing dead npcs in menu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 group = 'com.menuhp'
-version = '1.1.2'
+version = '1.1.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/menuhp/MenuHpPlugin.java
+++ b/src/main/java/com/menuhp/MenuHpPlugin.java
@@ -131,22 +131,30 @@ public class MenuHpPlugin extends Plugin
                         ratio = npcRatios.get(npc);
                     }
                 }
-                else if (npc.getHealthRatio() > 0) {
+                else if (npc.getHealthRatio() >= 0)
+                {
                     ratio = ((double) npc.getHealthRatio() / (double) npc.getHealthScale());
                 }
-                if (ratio != -1 || config.recolorWhenUnknown())
+                else if (npc.isDead())
                 {
+                    ratio = 0;
+                }
+				if (ratio != -1 || config.recolorWhenUnknown())
+				{
                     int splitIndex = (int) Math.round(baseText.length() * Math.abs(ratio));
                     Color[] tagColors = getColorsFromTags(target);
-					boolean isHealthUnknown = ratio < 0;
+                    boolean isHealthUnknown = ratio < 0;
                     String finalText = buildFinalTargetText(cleanTarget, tagColors, splitIndex, baseText, levelText,
-						isHealthUnknown);
+                        isHealthUnknown);
 
                     MenuEntry[] menuEntries = client.getMenuEntries();
                     final MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
                     menuEntry.setTarget(finalText);
                     client.setMenuEntries(menuEntries);
-                    npcRatios.put(npc, ratio);
+                    if (!isHealthUnknown)
+                    {
+                        npcRatios.put(npc, ratio);
+                    }
                 }
 			}
 		}


### PR DESCRIPTION
Dead monsters are currently not being recolored by this plugin, so they appear the same as "unknown" hp monsters. It makes more sense to give them a health ratio of zero.

Also made a small adjustment to only track npc health ratio when it is known, as it would just clog up the health ratio map otherwise.